### PR TITLE
Updates com.puppycrawl.tools.checkstyle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.6</slf4j.version>
     <aws.sdk.version>1.11.393</aws.sdk.version>
+    <duraspace-codestyle.version>1.0.0</duraspace-codestyle.version>
   </properties>
 
   <distributionManagement>
@@ -222,20 +223,16 @@
         <executions>
           <execution>
             <id>verify-style</id>
-            <!-- Bind to process-classes so it runs after compile, but before package -->
-            <phase>process-classes</phase>
+            <!-- Bind to verify so it runs after package & unit tests, but before install --> 
+            <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <configLocation>
-            https://raw.githubusercontent.com/duraspace/codestyle/master/duraspace-checkstyle.xml
-          </configLocation>
-          <suppressionsLocation>
-            https://raw.githubusercontent.com/duraspace/codestyle/master/duraspace-checkstyle-suppressions.xml
-          </suppressionsLocation>
+          <configLocation>duraspace-checkstyle/checkstyle.xml</configLocation>
+          <suppressionsLocation>duraspace-checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
           <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <logViolationsToConsole>true</logViolationsToConsole>
@@ -243,11 +240,16 @@
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
         <dependencies>
+          <dependency>
+             <groupId>org.duraspace</groupId>
+             <artifactId>codestyle</artifactId>
+             <version>${duraspace-codestyle.version}</version>
+          </dependency>
           <!-- Override dependencies to use latest version of checkstyle -->
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.8</version>
+            <version>8.21</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
and anchors duraspace checkstyle to the deployed jar rather than github master.